### PR TITLE
Fix helper finding from within views

### DIFF
--- a/Rails.py
+++ b/Rails.py
@@ -66,7 +66,7 @@ class RailsRelatedFilesHelper:
     walkers = [
       'models/'             + model + '**',
       'views/'              + working_directory_base + '/**',
-      'helpers'             + working_directory_base + '/**',
+      'helpers/'            + model + '**',
       'assets/javascripts/' + model + '**',
       'assets/stylesheets/' + model + '**',
       'controllers/'        + controller + '**'
@@ -229,4 +229,4 @@ class RailsRelatedFilesCommand(sublime_plugin.TextCommand):
       return os.path.dirname(file_name)
     else:
       return self.window.folders()[0]
-    
+


### PR DESCRIPTION
Cmd-Shift-O doesn't correctly locate helper files when you're in a view file. This commit fixes that.
