### PR TITLE
Opening helpers directly from controllers/models with cmd-shift-O

### DIFF
--- a/Rails.py
+++ b/Rails.py
@@ -83,6 +83,7 @@ class RailsRelatedFilesHelper:
     
     walkers = [
       'models/'         + model      + '**',
+      'helpers/'        + model      + '**',  # Helpers
       'views/'          + controller + '/**', # Views
       'views/**/'       + controller + '/**',  # Views
       'controllers/'    + controller + '**',  # Controllers looks under controllers/model** 


### PR DESCRIPTION
This one isn't a bug fix, but I find it useful so I wanted to see if you'd consider accepting this as well.

When I hit Cmd-Shift-O the helper isn't always there. Looking into the code I find that this is only the case when I'm in a view.  This makes complete sense, so I'll understand if you don't want to merge this PR, but I've found it very useful to be able to jump over directly to the helper.  Sometimes I'll just know that's where I need to get to, even if I'm in a controller.
